### PR TITLE
Close geocoder on click outside

### DIFF
--- a/src/app/[lang]/components/Map/index.tsx
+++ b/src/app/[lang]/components/Map/index.tsx
@@ -41,6 +41,7 @@ import useWindowSize from "@/hooks/useWindowSize";
 import Link from "next/link";
 import Image from "next/image";
 import Logo from "@/app/[lang]/components/Nav/logo.svg";
+import useGeocoderClickOutside from "@/hooks/useClickOutsideGeocoder";
 
 interface MainMapProps {
   dictionary: { [key: string]: any };
@@ -81,6 +82,7 @@ const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
   const hoveredFeatureRef = useRef<string | number | undefined>(undefined);
   const orderedLayerSetRef = useRef<string>("");
   const popupRef = useRef<mapboxgl.Popup | null>(null);
+  const geocoderContainerRef = useRef<HTMLDivElement | null>(null);
 
   const {
     miningData,
@@ -335,6 +337,13 @@ const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
     };
   }, []);
 
+  // click outside handler for geocoder
+  useGeocoderClickOutside(
+    isGeocoderHidden,
+    geocoderContainerRef,
+    setIsGeocoderHidden,
+  );
+
   // in case we're in an iframe embed, this sends a post message to the parent window,
   // for the mining calculator
   const miningLocations = selectedAreaData?.properties?.locations;
@@ -403,6 +412,9 @@ const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
           geocoderContainer.style.top = "calc(var(--top-navbar-height) + 10px)";
           geocoderContainer.style.right = "10px";
           geocoderContainer.style.zIndex = "1000";
+
+          // store ref to the container
+          geocoderContainerRef.current = geocoderContainer;
 
           const mapContainer = document.querySelector(".main-map");
           if (mapContainer) {

--- a/src/hooks/useClickOutsideGeocoder.ts
+++ b/src/hooks/useClickOutsideGeocoder.ts
@@ -1,0 +1,36 @@
+import { useEffect, RefObject } from "react";
+
+const useGeocoderClickOutside = (
+  isGeocoderHidden: boolean,
+  geocoderContainerRef: RefObject<HTMLElement>,
+  setIsGeocoderHidden: (_state: boolean) => void,
+) => {
+  useEffect(() => {
+    if (isGeocoderHidden) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      // check if outside
+      if (
+        geocoderContainerRef.current &&
+        !geocoderContainerRef.current.contains(target) &&
+        !target.closest(".mapboxgl-ctrl-geocoder")
+      ) {
+        geocoderContainerRef.current.classList.add("geocoder-hidden");
+        setIsGeocoderHidden(true);
+      }
+    };
+
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("click", handleClickOutside);
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [isGeocoderHidden, geocoderContainerRef, setIsGeocoderHidden]);
+};
+
+export default useGeocoderClickOutside;


### PR DESCRIPTION
Closes #144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only behavior change limited to the geocoder visibility logic; low likelihood of broader side effects beyond click handling.
> 
> **Overview**
> Closes the Mapbox geocoder search UI when the user clicks outside of it.
> 
> Adds a new `useGeocoderClickOutside` hook that attaches a document click listener (only while the geocoder is open) and hides the geocoder by re-applying the `geocoder-hidden` class and updating `isGeocoderHidden`. The map component now stores a ref to the dynamically-created geocoder container and wires it into this hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d644c6f828e9443f2947aa05b5d3ff12b914943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->