### PR TITLE
Update data to 20260212

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -2,7 +2,7 @@ import { scaleSequential } from "d3-scale";
 import { interpolateRgbBasis } from "d3-interpolate";
 import { HOTSPOTS_GEOJSON_URL } from "@/cms/hotspots";
 
-const DATA_UPDATED_AT = "20260124";
+const DATA_UPDATED_AT = "20260212";
 const DATA_BASE_URL =
   // "/website";
   `${process.env.NEXT_PUBLIC_DATA_URL}/${DATA_UPDATED_AT}`;


### PR DESCRIPTION
Closes #148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple constant change that repoints data URLs; main risk is broken/missing data if the new snapshot path isn’t available or compatible.
> 
> **Overview**
> Bumps the data version used to build `DATA_BASE_URL` in `src/constants/map.ts` from `20260124` to `20260212`, causing all map layer/boundary URLs derived from `DATA_BASE_URL` to point at the newer dataset snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90cb8d263e64901c228bcb1f991e30ab29cc656b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->