### PR TITLE
Data update, split IT polygons without name

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,7 +1,7 @@
 import { scaleSequential } from "d3-scale";
 import { interpolateRgbBasis } from "d3-interpolate";
 
-const DATA_UPDATED_AT = "20260224";
+const DATA_UPDATED_AT = "20260331";
 const DATA_BASE_URL =
   // "/website";
   `${process.env.NEXT_PUBLIC_DATA_URL}/${DATA_UPDATED_AT}`;


### PR DESCRIPTION
Closes #165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk (single constant change), but it will switch all map/vector tile requests to the new dated dataset, so missing or mismatched deployed assets would break map layers.
> 
> **Overview**
> Updates the map data/version stamp (`DATA_UPDATED_AT`) from `20260224` to `20260331`, causing `DATA_BASE_URL` and `TILES_BASE_URL` to point to the newly dated dataset for all boundary JSON and vector tile layer URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13597541f28d9e4bb3f8cfa6d298c084a3b4b7c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->