### PR TITLE
Update data to split IT polygons without name

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,7 +1,7 @@
 import { scaleSequential } from "d3-scale";
 import { interpolateRgbBasis } from "d3-interpolate";
 
-const DATA_UPDATED_AT = "20260224";
+const DATA_UPDATED_AT = "20260331";
 const DATA_BASE_URL =
   // "/website";
   `${process.env.NEXT_PUBLIC_DATA_URL}/${DATA_UPDATED_AT}`;


### PR DESCRIPTION
Closes #165 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `DATA_UPDATED_AT` version string, changing which remote data/tiles URLs the app points to without modifying runtime logic.
> 
> **Overview**
> Updates the map data version by bumping `DATA_UPDATED_AT` from `20260224` to `20260331`, causing all `DATA_BASE_URL` and `TILES_BASE_URL` references to load the newer published dataset/tiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c668a1d247ecab8720b38fe2bdde9317f96c8d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->