### PR TITLE
Fix tooltip for entire Amazon

### DIFF
--- a/src/app/[lang]/components/Map/index.tsx
+++ b/src/app/[lang]/components/Map/index.tsx
@@ -83,6 +83,15 @@ const AREAS_LAYER_FILTER = [
   ["!", ["in", ["get", "id"], ["literal", AREA_IDS_TO_HIDE]]],
 ];
 
+const filterInteractiveFeatures = (features: mapboxgl.MapboxGeoJSONFeature[]) =>
+  features.filter(
+    (d) =>
+      // ignore entire amazon layer as it covers everything
+      d?.properties?.id !== ENTIRE_AMAZON_AREA_ID &&
+      // ignore layers except the areas one
+      d?.layer?.id === "areas-layer-fill",
+  );
+
 const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
   const [state, dispatch] = useContext(Context)!;
   const pathname = usePathname();
@@ -186,9 +195,11 @@ const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
 
   const handleMouseMove = useCallback(
     (event: MapMouseEvent) => {
-      if (isMobile || !mapRef.current || !popupRef.current) return;
+      if (isMobile || !mapRef.current || !popupRef.current || !event.features)
+        return;
 
-      const feature = event.features?.[0];
+      const featuresFiltered = filterInteractiveFeatures(event.features);
+      const feature = featuresFiltered?.[0];
       const map = event.target;
 
       if (!feature?.properties) {
@@ -274,13 +285,7 @@ const MainMap: React.FC<MainMapProps> = ({ dictionary }) => {
       );
       if (clickedOnExcludedLayer) return;
 
-      const featuresFiltered = features.filter(
-        (d) =>
-          // ignore entire amazon layer as it covers everything
-          d?.properties?.id !== ENTIRE_AMAZON_AREA_ID &&
-          // ignore layers except the areas one
-          d?.layer?.id === "areas-layer-fill",
-      );
+      const featuresFiltered = filterInteractiveFeatures(features);
       const feature = featuresFiltered[0];
       const id = feature?.properties?.id;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to map hover/click feature selection that only affects tooltip/selection behavior.
> 
> **Overview**
> Fixes map hover/click behavior so tooltips and area selection ignore the synthetic “entire Amazon” feature and only consider `areas-layer-fill` features.
> 
> Refactors the filtering into a shared `filterInteractiveFeatures` helper and adds a guard to `handleMouseMove` to skip processing when `event.features` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd4a9d92b2862aa0c1453ec8f3d2ebfc3649850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->