### PR TITLE
New imagery for 2018-2023

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -15,7 +15,7 @@ if (!DATA_BASE_URL) {
   );
 }
 
-const SENTINEL2_TEMPORAL = "v1/tiles/sentinel2-temporal-mosaics";
+const SENTINEL2_AMW = "v1/tiles/amw-sentinel2-yearly-mosaics";
 const SENTINEL2_YEARLY = "v1/tiles/sentinel2-yearly-mosaics";
 const SENTINEL2_SEMIANNUAL = "v1/tiles/sentinel2-semiannual-mosaics";
 const SENTINEL2_QUARTERLY = "v1/tiles/sentinel2-quarterly-mosaics";
@@ -23,32 +23,32 @@ const SENTINEL2_QUARTERLY = "v1/tiles/sentinel2-quarterly-mosaics";
 export const MINING_LAYERS = [
   {
     yearQuarter: 201800,
-    satelliteEndpoint: SENTINEL2_TEMPORAL,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2018-01-01/2019-01-01",
   },
   {
     yearQuarter: 201900,
-    satelliteEndpoint: SENTINEL2_TEMPORAL,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2019-01-01/2020-01-01",
   },
   {
     yearQuarter: 202000,
-    satelliteEndpoint: SENTINEL2_TEMPORAL,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2020-01-01/2021-01-01",
   },
   {
     yearQuarter: 202100,
-    satelliteEndpoint: SENTINEL2_TEMPORAL,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2021-01-01/2022-01-01",
   },
   {
     yearQuarter: 202200,
-    satelliteEndpoint: SENTINEL2_TEMPORAL,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2022-01-01/2023-01-01",
   },
   {
     yearQuarter: 202300,
-    satelliteEndpoint: SENTINEL2_YEARLY,
+    satelliteEndpoint: SENTINEL2_AMW,
     satelliteDates: "2023-01-01/2024-01-01",
   },
   {


### PR DESCRIPTION
## Summary

Updates the imagery for 2018-2023 to fix missing areas identified in #109.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible change to map tile endpoints for multiple years; risk is mainly misconfigured/invalid endpoints or missing imagery causing blank/incorrect basemaps.
> 
> **Overview**
> Updates the mining map raster imagery configuration so **2018–2023 layers** use the new `v1/tiles/amw-sentinel2-yearly-mosaics` endpoint instead of the previous temporal/yearly source.
> 
> This removes the old `SENTINEL2_TEMPORAL` constant and repoints the affected `MINING_LAYERS` entries, leaving 2024+ layers on their existing endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677f7b02adbe8cb3230327b9a4c2a0feb9cd88ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->