### PR TITLE
New 2024 imagery

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -16,7 +16,7 @@ if (!DATA_BASE_URL) {
 }
 
 const SENTINEL2_AMW = "v1/tiles/amw-sentinel2-yearly-mosaics";
-const SENTINEL2_YEARLY = "v1/tiles/sentinel2-yearly-mosaics";
+const SENTINEL2_YEARLY = "v1/tiles/sentinel2-yearly-mosaics-v4";
 const SENTINEL2_SEMIANNUAL = "v1/tiles/sentinel2-semiannual-mosaics";
 const SENTINEL2_QUARTERLY = "v1/tiles/sentinel2-quarterly-mosaics";
 


### PR DESCRIPTION
## Summary

Points the 2024 imagery map layer to the newest 2024 imagery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated configuration change that only affects which raster tile source is used for the 2024 imagery layer; main risk is broken/mismatched tiles if the new endpoint is unavailable or incompatible.
> 
> **Overview**
> Updates the Sentinel-2 yearly imagery tiles endpoint used for the 2024 map layer by switching `SENTINEL2_YEARLY` from `v1/tiles/sentinel2-yearly-mosaics` to `v1/tiles/sentinel2-yearly-mosaics-v4`, so the 2024 imagery renders from the newer dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5194a815361f78b4dd5d577c3a3a0c80befbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->