### PR TITLE
Use new 2025 q1 and q2 imagery

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -58,13 +58,13 @@ export const MINING_LAYERS = [
   },
   {
     yearQuarter: 202501,
-    satelliteEndpoint: SENTINEL2_AMW_SEMIANNUAL,
-    satelliteDates: "2025-02-15/2025-08-15",
+    satelliteEndpoint: SENTINEL2_AMW_QUARTERLY,
+    satelliteDates: "2025-01-01/2025-04-01",
   },
   {
     yearQuarter: 202502,
-    satelliteEndpoint: SENTINEL2_AMW_SEMIANNUAL,
-    satelliteDates: "2025-02-15/2025-08-15",
+    satelliteEndpoint: SENTINEL2_AMW_QUARTERLY,
+    satelliteDates: "2025-04-01/2025-07-01",
   },
   {
     yearQuarter: 202503,

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -17,7 +17,6 @@ if (!DATA_BASE_URL) {
 
 const SENTINEL2_AMW_YEARLY = "v1/tiles/amw-sentinel2-yearly-mosaics";
 const SENTINEL2_GLOBAL_YEARLY = "v1/tiles/sentinel2-yearly-mosaics-v4";
-const SENTINEL2_AMW_SEMIANNUAL = "v1/tiles/amw-sentinel2-semiannual-mosaics";
 const SENTINEL2_AMW_QUARTERLY = "v1/tiles/amw-sentinel2-quarterly-mosaics";
 
 export const MINING_LAYERS = [


### PR DESCRIPTION
## Summary

Swaps out the 2025 combined q1+q2 semiannual tileset for the new separate q1 and q2 tilesets. These are cloudier but more accurately depict each individual quarter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to satellite tile URLs and date ranges in map constants; no auth, data pipeline, or application logic changes.
> 
> **Overview**
> Updates **2025 Q1** (`202501`) and **Q2** (`202502`) mining map layers to use the **quarterly** Sentinel-2 mosaic endpoint instead of a single **semiannual** tileset that covered both quarters together.
> 
> Each quarter now has its own date window (`2025-01-01/2025-04-01` and `2025-04-01/2025-07-01`), aligning with Q3/Q4 and trading the old combined semiannual imagery for per-quarter tiles. The unused `SENTINEL2_AMW_SEMIANNUAL` constant is removed from `map.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac11638bfb8d0c1c697f0fe5022b9d00428a0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->