### PR TITLE
Fix formatNumber rendering values just under 1 billion with d3's "G" suffix

### DIFF
--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -55,8 +55,10 @@ export const formatNumber = (
   // If number is <1, display it "<1"
   if (number < 1 && number > 0) return `<1`;
 
-  // If number is >= 1 billion, format as millions instead of using the "giga" / "G" from d3 format
-  if (Math.abs(number) >= 1_000_000_000) {
+  // If number is >= 1 billion, format as millions instead of using the "giga" / "G" from d3 format.
+  // Compare the value rounded to significantDigits: the d3 s-formatter below rounds too, so a value
+  // just under 1e9 (e.g. 997,000,000) would otherwise be bumped up into the "G" prefix this avoids.
+  if (Math.abs(numberToSignificantDigits(number, significantDigits)) >= 1_000_000_000) {
     const formatter = locale.format(",.0~f");
     const numberInMillions = number / 1_000_000;
     const numberSignificantDigits = numberToSignificantDigits(


### PR DESCRIPTION
This PR proposes a fix to `formatNumber` (`src/utils/content.ts`) so that large values just under one billion render in the intended millions notation instead of d3's "G" (giga) suffix. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/317. You can sign in with your GitHub ID to claim ownership of the project.

## What's wrong

`formatNumber` deliberately special-cases large values: its own comment says it formats them "as millions instead of using the 'giga' / 'G' from d3 format", and the `>= 1_000_000_000` branch renders `1_000_000_000` as `1,000M`. The guard, however, compares the **raw** value, while the d3 SI formatter on the fallback path (`,.${significantDigits}~s`) rounds to `significantDigits` first. A value just under 1e9 slips past the guard and is then rounded **up** into the exact "G" prefix that branch exists to avoid. With `ECONOMIC_COST_SIGNIFICANT_DIGITS = 2`, an economic cost of `997,000,000` renders as `1G` while `1,000,000,000` renders as `1,000M` — the notation flips across a boundary that should be seamless. `formatNumber` is on the hot path for the area card and the mining-area chart, so this shows up directly in the AreaSummary economic-cost readout.

## Reproduce on `main`

Run inside the repo (so `d3` resolves), reproducing the current guard verbatim:

```js
import { formatLocale } from "d3";
const loc = formatLocale({ decimal: ".", thousands: ",", grouping: [3], currency: ["$", ""], percent: "%" });
const nts = (n, s) => parseFloat(n.toPrecision(s));
// the >= 1e9 guard exactly as on main: it tests the RAW value
const onMain = (n, sig) =>
  Math.abs(n) >= 1_000_000_000
    ? loc.format(",.0~f")(nts(n / 1e6, sig)) + "M"
    : loc.format(`,.${sig}~s`)(n || 0);

console.log(onMain(997_000_000, 2));   // "1G"      <- want "1,000M"
console.log(onMain(1_000_000_000, 2)); // "1,000M"
```

## The change

Compare the value **after** rounding to `significantDigits`, so values that round up to 1e9 also take the millions branch:

```diff
-  if (Math.abs(number) >= 1_000_000_000) {
+  if (Math.abs(numberToSignificantDigits(number, significantDigits)) >= 1_000_000_000) {
```

## Verification

The repo has no test runner, so here is a self-contained check you can replay: it formats every value from 9.0e8 to 1.1e9 with `significantDigits` 1–3 across all three locales (en/es/pt), comparing the current guard against the patched one. The current code renders the roughly [9.5e8, 1e9) band as "…G"; the patched `formatNumber` never emits a "G" and leaves **every** other output identical — only the previously-"G" values move to millions notation. `npx tsc --noEmit` and `npx next lint` both stay green with the change applied (no new failures against a clean checkout).

| value (sig=2, en) | `main` | this PR |
| --- | --- | --- |
| `$949,999,999` | `950M` | `950M` (unchanged) |
| `$997,000,000` | `1G` | `1,000M` (fixed) |
| `$999,999,999` | `1G` | `1,000M` (fixed) |
| `$1,000,000,000` | `1,000M` | `1,000M` (unchanged) |

The fix is backward-compatible: `formatNumber`'s signature is unchanged and no output outside the affected band moves, so existing callers keep their current formatting.

## How this was managed

We imported this repository's issues and pull requests into a live board (159 stories, plus your milestones as epics and labels) and used it to track this fix. The specific story for this change, with the same reproduction and notes, is at https://eastagiletracker.com/projects/317/stories/209631 ; the full board is at https://eastagiletracker.com/projects/317 .

![board](https://raw.githubusercontent.com/eastagiletracker/amw-frontend/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single localized formatting guard in a shared util; behavior change is limited to large numbers near 1e9 with no security or data implications.
> 
> **Overview**
> **`formatNumber`** in `content.ts` fixes inconsistent display for large economic costs (e.g. area summary and mining chart).
> 
> The **≥1 billion** branch that formats as **millions** (`…M`) instead of d3's **giga** (`G`) now compares **`numberToSignificantDigits(number, significantDigits)`** to `1_000_000_000`, not the raw value. That matches how the fallback d3 `s` formatter rounds, so values like **997,000,000** with two significant digits take the millions path (**1,000M**) instead of rounding up to **1G**.
> 
> Comments clarify why the rounded comparison is needed. No API or caller changes; only outputs in the band that previously showed **G** change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45cd42f96bf1cac750d49b921d8957cd3e6f8b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->