### PR TITLE
Update data to 20260822

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,7 +1,7 @@
 import { scaleSequential } from "d3-scale";
 import { interpolateRgbBasis } from "d3-interpolate";
 
-const DATA_UPDATED_AT = "20260724";
+const DATA_UPDATED_AT = "20260822";
 const DATA_BASE_URL =
   // "/website";
   `${process.env.NEXT_PUBLIC_DATA_URL}/${DATA_UPDATED_AT}`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> One-line config change to data/tile URLs. Risk is limited to serving the wrong snapshot if the 20260822 assets are missing or incomplete.
> 
> **Overview**
> Points the app at the **20260822** mining data release by bumping `DATA_UPDATED_AT` in `src/constants/map.ts` from `20260724`.
> 
> That updates `DATA_BASE_URL` and `TILES_BASE_URL`, so boundary JSON, timeseries, and vector tiles all load from the new snapshot. No layer list or other map logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2da6fcccdbfadbb339aaa1f3ffb31e7a2eda14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->