### PR TITLE
Use increased significant digits for area bar chart

### DIFF
--- a/src/app/[lang]/components/AreaSummary/MiningAreaBarChart/index.tsx
+++ b/src/app/[lang]/components/AreaSummary/MiningAreaBarChart/index.tsx
@@ -51,7 +51,7 @@ const MiningAreaBarChart = ({
       ...d,
       area_ha_significant: numberToSignificantDigits(
         d.intersected_area_ha_cumulative,
-        getAreaSignificantDigits(d.intersected_area_ha_cumulative),
+        getAreaSignificantDigits(d.intersected_area_ha_cumulative, 2),
       ),
     }));
 

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -276,10 +276,10 @@ export const ILLEGALITY_COLORS = {
 
 export type PERMITTED_ILLEGALITY_KEYS = keyof typeof ILLEGALITY_KEYS;
 
-export const getAreaSignificantDigits = (number: number) => {
-  if (number < 10) return 1;
-  if (number < 1000) return 2;
-  return 3;
+export const getAreaSignificantDigits = (number: number, base = 1) => {
+  if (number < 10) return base;
+  if (number < 1000) return base + 1;
+  return base + 2;
 };
 
 export const ECONOMIC_COST_SIGNIFICANT_DIGITS = 2;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only number formatting in one chart component; other callers keep prior behavior via the default `base`.
> 
> **Overview**
> **Extends `getAreaSignificantDigits`** with an optional `base` argument (default `1`) so digit counts scale as `base`, `base + 1`, or `base + 2` by magnitude instead of fixed 1/2/3.
> 
> **Mining area bar chart** passes `base` of `2` when rounding cumulative intersected area for bar heights and year-over-year `area_change_ha`, so those values show one extra significant figure than the rest of the app (which still uses the default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6230a6899ac2654f6346f041153af1e58b870a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->