### PR TITLE
Update data to 20260829

### DIFF
--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,7 +1,7 @@
 import { scaleSequential } from "d3-scale";
 import { interpolateRgbBasis } from "d3-interpolate";
 
-const DATA_UPDATED_AT = "20260822";
+const DATA_UPDATED_AT = "20260829";
 const DATA_BASE_URL =
   // "/website";
   `${process.env.NEXT_PUBLIC_DATA_URL}/${DATA_UPDATED_AT}`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant change with no application logic updates; main operational risk is missing or mismatched assets at the new snapshot URL.
> 
> **Overview**
> Bumps the **`DATA_UPDATED_AT`** snapshot in `src/constants/map.ts` from **`20260822`** to **`20260829`**.
> 
> Because **`DATA_BASE_URL`** and **`TILES_BASE_URL`** are built from that constant, the app will load JSON impact dictionaries, yearly timeseries, and vector tiles (including mining layers) from the new dated paths on the configured public data/tiles hosts—no other logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e35546acef2fde687e123085256f129adaf89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->